### PR TITLE
Fix uninstallation

### DIFF
--- a/PartialityLauncher/PartialityLauncher/Mod Management/GameManager.cs
+++ b/PartialityLauncher/PartialityLauncher/Mod Management/GameManager.cs
@@ -127,8 +127,11 @@ namespace PartialityLauncher {
             string backupFolder = managedFolder + "_backup";
 
             if( Directory.Exists( backupFolder ) ) {
-                //Delete original, the re-create it
+                //Delete original, then re-create it
                 Directory.Delete( managedFolder, true );
+                while ( Directory.Exists( managedFolder ) )
+                    System.Threading.Thread.Sleep(10);
+                }
                 Directory.CreateDirectory( managedFolder );
                 //Copy files from backup
                 PatchManager.CopyFilesRecursively( backupFolder, managedFolder );


### PR DESCRIPTION
Using the "Uninstall Partiality" button consistently fails for me.

The problem seems to be that `Directory.Delete` is not synchronous. When the `Managed` directory is deleted it can take some time to complete, causing its immediate recreation to happen too early which ultimately leads to there not being a `Managed` directory when Partiality starts to copy over files from the backup directory which then causes an exception and crashes the launcher.

See for example also this stack overflow post: https://stackoverflow.com/questions/35069311/why-sometimes-directory-createdirectory-fails

This PR should fix the problem by ensuring the directory is really deleted before recreating it.